### PR TITLE
Add and document the ParseResultStringUtils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.log/

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ Properties / Methods:
 - `t.transformOneSync()`
 - `t.transformOne()`
 - `t.reverseInnerCoordinatesOf()` Given in-template coordinates, returns the coordinates in the context of the file
+- `t.stringUtils` Collection of utilities for working with parseResults 
+- `t.stringUtils.contentBefore(parseResult)` return the string contents before the passed parse result, before the opening `<template>`
+- `t.stringUtils.originalContentOf(parseResult)` returns the original content of the parseResult, prior to any transformations  
+- `t.stringUtils.openingTag(parseResult)` returns the opening `<template>` including any attributes are key-value pairs it may have on it 
+- `t.stringUtils.closingTag(parseResult)` returns the clasing `</template>` which is expected to always be `=== '</template'`  
 
 ### transform + transformSync
 

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -80,6 +80,16 @@ export class Transformer {
   }
 
   /**
+   * Utils for viewing the parts of a parseResult
+   * with in JS-character-byte range
+   *
+   * @type {ParseResultStringUtils}
+   */
+  get stringUtils() {
+    return this.#stringUtils;
+  }
+
+  /**
    * For a given set of coordinates, find the parseResult and return it
    * You don't need to provide the whole original coordinates object.
    * Though, you can!

--- a/tests/transformer.StringUtils.test.ts
+++ b/tests/transformer.StringUtils.test.ts
@@ -1,17 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { ParseResultStringUtils } from "content-tag-utils";
+import { Transformer, ParseResultStringUtils } from "content-tag-utils";
 import { Preprocessor } from "content-tag";
 
 const p = new Preprocessor();
-
-function create(content: string) {
-  let buffer = Buffer.from(content, "utf8");
-
-  return {
-    stringUtils: new ParseResultStringUtils(buffer),
-    parseResults: p.parse(content),
-  };
-}
 
 let simpleTemplate = [
   "export const Name = <template>",
@@ -24,7 +15,82 @@ let simpleTemplate = [
   "",
 ].join("\n");
 
-describe("StringUtils", () => {
+describe("ParseResultStringUtils", () => {
+  function create(content: string) {
+    let buffer = Buffer.from(content, "utf8");
+
+    return {
+      stringUtils: new ParseResultStringUtils(buffer),
+      parseResults: p.parse(content),
+    };
+  }
+
+  describe("contentBefore", () => {
+    it("works", () => {
+      let x = create(simpleTemplate);
+
+      let result = x.stringUtils.contentBefore(x.parseResults[0]!);
+      let result2 = x.stringUtils.contentBefore(x.parseResults[1]!);
+
+      expect(result).toMatchInlineSnapshot(`"export const Name = "`);
+      expect(result2).toMatchInlineSnapshot(`
+        "export const Name = <template>
+          {{@name}}
+        </template>;
+
+        export const Greeting = "
+      `);
+    });
+  });
+
+  describe("originalContentOf", () => {
+    it("works", () => {
+      let x = create(simpleTemplate);
+
+      let result = x.stringUtils.originalContentOf(x.parseResults[0]!);
+      let result2 = x.stringUtils.originalContentOf(x.parseResults[1]!);
+
+      expect(result).toMatchInlineSnapshot(`
+        "
+          {{@name}}
+        "
+      `);
+      expect(result2).toMatchInlineSnapshot(`
+        "
+          Hello, <Name @name={{@name}} />!
+        "
+      `);
+    });
+  });
+  describe("openingTag", () => {
+    it("works", () => {
+      let x = create(simpleTemplate);
+
+      let result = x.stringUtils.openingTag(x.parseResults[0]!);
+      let result2 = x.stringUtils.openingTag(x.parseResults[1]!);
+
+      expect(result).toMatchInlineSnapshot(`"<template>"`);
+      expect(result2).toMatchInlineSnapshot(`"<template>"`);
+    });
+  });
+  describe("closingTag", () => {
+    it("works", () => {
+      let x = create(simpleTemplate);
+
+      let result = x.stringUtils.closingTag(x.parseResults[0]!);
+      let result2 = x.stringUtils.closingTag(x.parseResults[1]!);
+
+      expect(result).toMatchInlineSnapshot(`"</template>"`);
+      expect(result2).toMatchInlineSnapshot(`"</template>"`);
+    });
+  });
+});
+
+describe("stringUtils", () => {
+  function create(content: string) {
+    return new Transformer(content);
+  }
+
   describe("contentBefore", () => {
     it("works", () => {
       let x = create(simpleTemplate);


### PR DESCRIPTION
Exposes the stringUtils so folks can ask questions about the opening and closing regions of the template contents